### PR TITLE
Sample workaround for flywaydb-5.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
       <dependency>
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>
-			<version>3.2.1</version>
+			<version>5.2.4</version>
 		</dependency>
   </dependencies>
 </project>

--- a/src/main/java/com/barryku/karaf/flyway/DbMigrationService.java
+++ b/src/main/java/com/barryku/karaf/flyway/DbMigrationService.java
@@ -3,6 +3,7 @@ package com.barryku.karaf.flyway;
 import javax.sql.DataSource;
 
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.logging.LogFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,6 +15,7 @@ public class DbMigrationService {
 
 	public void doMigration() {
 		logger.info("============== karaf flyway migrateion demo =============");
+                LogFactory.setLogCreator(new Slf4jLogCreator());
 		ClassLoader thisClassLoader = this.getClass().getClassLoader();
 		getFlyway().setDataSource(datasource);
 		getFlyway().setClassLoader(thisClassLoader);

--- a/src/main/java/com/barryku/karaf/flyway/Slf4jLog.java
+++ b/src/main/java/com/barryku/karaf/flyway/Slf4jLog.java
@@ -1,0 +1,46 @@
+package com.barryku.karaf.flyway;
+
+import org.flywaydb.core.api.logging.Log;
+import org.slf4j.Logger;
+
+/** Workaround flywaydb-5.2.4 bad OSGi log factory. */
+class Slf4jLog implements Log {
+    /**
+     * Slf4j Logger.
+     */
+    private final Logger logger;
+
+    /**
+     * Creates a new wrapper around this logger.
+     *
+     * @param logger The original Slf4j Logger.
+     */
+    public Slf4jLog(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return logger.isDebugEnabled();
+    }
+
+    public void debug(String message) {
+        logger.debug(message);
+    }
+
+    public void info(String message) {
+        logger.info(message);
+    }
+
+    public void warn(String message) {
+        logger.warn(message);
+    }
+
+    public void error(String message) {
+        logger.error(message);
+    }
+
+    public void error(String message, Exception e) {
+        logger.error(message, e);
+    }
+}

--- a/src/main/java/com/barryku/karaf/flyway/Slf4jLogCreator.java
+++ b/src/main/java/com/barryku/karaf/flyway/Slf4jLogCreator.java
@@ -1,0 +1,13 @@
+package com.barryku.karaf.flyway;
+
+
+import org.flywaydb.core.api.logging.Log;
+import org.flywaydb.core.api.logging.LogCreator;
+import org.slf4j.LoggerFactory;
+
+/** Workaround flywaydb-5.2.4 bad OSGi log factory. */
+class Slf4jLogCreator implements LogCreator {
+    public Log createLogger(Class<?> clazz) {
+        return new Slf4jLog(LoggerFactory.getLogger(clazz));
+    }
+}


### PR DESCRIPTION
Hi! I've found your sample project most useful, so I decided to create this PR as a sample on how I managed to hack flywaydb-5.2.4 so that it can be started in karaf-4.1.5 when encountering the following problem:

java.lang.ClassNotFoundException: org.flywaydb.core.internal.logging.javautil.JavaUtilLogCreator

A better description of the error is https://stackoverflow.com/questions/56371272/flyway-classnotfoundexception-javautillogcreator

This was copied from my own project, again as a sample. I have not tested it, but I think it helps getting the idea through.

Those `Slf4j` classes could in theory be used directly from the `flywaydb-core` bundle, but their packages are private, so they cannot be used here.